### PR TITLE
Initial scaffold and API design

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "extends": "@hapi/hapi",
+
+  "parserOptions": {
+    "ecmaVersion": 2019
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+**/node_modules
+**/package-lock.json
+**/npm-shrinkwrap.json
+
+coverage.*
+*.log*
+test-results.xml
+
+**/.DS_Store
+**/._*
+
+**/*.pem
+
+**/.vs
+**/.vscode
+**/.idea

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: node_js
+sudo: false
+
+node_js:
+  - "10"
+  - "12"
+  - "13"
+
+cache:
+  npm: false
+
+install:
+  - "npm install --ignore-scripts"
+  - "npx allow-scripts"
+
+#@todo uncomment before v1
+#jobs:
+#  include:
+#    - stage: release
+#      if: branch = master AND type = push
+#      node_js: "12"
+#      deploy:
+#        provider: "script"
+#        skip_cleanup: true
+#        script:
+#          - "npx semantic-release"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,86 @@
 # node-support
+
 List the Node.js versions supported by the package/repository
+
+## Usage (command line)
+
+```
+$ npx node-support [path]
+```
+
+Prints the supported Node.js versions for the package at the specified path. When the path is not a git repository - tries to read the git repository from `package.json` and tries to detect the versions listed in the repository as well.
+
+When `path` is omitted, tries to detect the versions for `cwd`. 
+
+```
+$ npx node-support [package name]
+```
+
+Prints supported Node.js versions for the package from the registry.
+
+```
+$ npx node-support [repository git URL]
+```
+
+Prints supported Node.js versions for the package at the git URL.
+
+## Usage (library)
+
+```
+const result = await require('node-support').detect({ path });
+```
+
+`path` should be a folder in the local file system. When the path is not a git repository - tries to read the git repository from `package.json` and tries to detect the versions listed in the repository as well. 
+
+```
+const result = await require('node-support').detect({ package });
+```
+
+`package` is a string name for the package in the registry. 
+
+```
+const result = await require('node-support').detect({ repository });
+```
+
+`repository` is a URL for a git repository.
+
+### Result
+
+- Throws if the `path` / `repository` does not have a `package.json`
+- Throws if `package` does not exist in the registry
+
+Otherwise returns an object with:
+
+```javascript
+const result = {
+
+    // the "name" field of the `package.json`
+    name: "package-name",    
+    
+    // the "version" field of the `package.json` when used with `path` / `repository`,
+    // the `latest` dist-tag version when used with `package`
+    version: "0.0.0",
+
+    // the current time when the result is returned
+    timestamp: 1577115956099,
+
+    // git commit hash of the repository HEAD at the time of scanning
+    // will be left out when no git repository detected
+    commit: "2de28c8c4ab8ac998d403509123736929131908c",
+
+    // will be left out when not present in the `package.json`
+    // a copy of the `engines.node` field from the `package.json` if present
+    engines: ">=x.y.z", 
+
+    // will be left out when `.travis.yml` file is not present
+    travis: {
+        // the list of versions as detected by inspecting `node_js` / `matrix` configuration
+        // will be an empty array when no versions are detected or the project is not a Node.js project
+        // will contain "latest" when `language: node_js` specified, but no explicit versions detected
+        raw: ["8", "10", "lts/*"],
+
+        // raw version specifiers and keywords resolved to exact Node.js versions
+        resolved: ["8.17.0", "10.18.0", "12.14.0"]
+    }
+}
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = () => {
+
+    throw new Error('Not implemented');
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "node-support",
+  "version": "0.0.0-development",
+  "description": "List the Node.js versions supported by the package/repository",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "lab -a @hapi/code -L -t 100"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pkgjs/node-support.git"
+  },
+  "author": "Dominykas Blyžė <hello@dominykas.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/pkgjs/node-support/issues"
+  },
+  "homepage": "https://github.com/pkgjs/node-support#readme",
+  "devDependencies": {
+    "@hapi/code": "^7.0.0",
+    "@hapi/lab": "^21.0.0",
+    "allow-scripts": "^1.5.2",
+    "semantic-release": "^15.14.0"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const NodeSupport = require('..');
+
+
+const { describe, it } = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+
+describe('node-support', () => {
+
+    it('is not implemented', () => {
+
+        expect(NodeSupport).to.throw('Not implemented');
+    });
+});


### PR DESCRIPTION
I will merge this in a few days, unless there's objections.

This is the MVP for detecting the Node.js versions a package is using in CI. The code will be extracted from https://github.com/dominykas/analyze-npm-top-1000.

I reserved the `node-support` package name, outside of the `@pkgjs` namespace, primarily because `npx node-support` is easier to type than `npx @pkgjs/node-support`, but also there's an annoying bug in npx when using namespaced packages: https://github.com/npm/npx/issues/25